### PR TITLE
Support zipfile scheme

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,8 @@ var import_coc2 = __toModule(require("coc.nvim"));
 var import_coc = __toModule(require("coc.nvim"));
 var documentSelector = [
   {scheme: "file", language: "clojure"},
-  {scheme: "jar", language: "clojure"}
+  {scheme: "jar", language: "clojure"},
+  {scheme: "zipfile", language: "clojure"}
 ];
 function getConfig() {
   const config = import_coc.workspace.getConfiguration("clojure");

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import { workspace } from "coc.nvim";
 export const documentSelector = [
 	{ scheme: "file", language: "clojure" },
 	{ scheme: "jar", language: "clojure" },
+	{ scheme: "zipfile", language: "clojure" },
 ];
 
 export interface Config {


### PR DESCRIPTION
Using the default dependency-scheme, `zip`, it's important to ensure
that the additional `documentSelector` scheme `zipfile` is set in order
for goto definition to work correctly (i.e., namely to goto definition
inside a loaded Clojure zip (jar) file dependency (like jumping to a
Clojure core function)).

This patch introduces the `zipfile` scheme to the documentSelector
array.

Fixes #1 

-=david=-